### PR TITLE
[ADD] A new task scheduling feature, handled by cron.

### DIFF
--- a/celery/data/ir_cron_data.xml
+++ b/celery/data/ir_cron_data.xml
@@ -60,5 +60,18 @@ model.autovacuum()
             <field name="priority">10</field>
             <field eval="False" name="doall" />
         </record>
+        <record id="ir_cron_celery_handle_scheduled_tasks" forcecreate="True" model="ir.cron">
+            <field name="name">Celery: Handle Scheduled Tasks</field>
+            <field name="model_id" ref="model_celery_task"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_handle_scheduled_tasks()</field>
+            <field name="active" eval="False"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">10</field>
+            <field name="interval_type">minutes</field>
+            <field name="numbercall">-1</field>
+            <field name="priority">10</field>
+            <field eval="False" name="doall" />
+        </record>
     </data>
 </odoo>

--- a/celery/models/celery_task.py
+++ b/celery/models/celery_task.py
@@ -168,7 +168,7 @@ class CeleryTask(models.Model):
 
         def get_next_hour_diff(current_hour, hour_from, hour_to, current_day_of_week, allowed_days):
             if current_hour <= hour_from:
-                if not allowed_days:
+                if not allowed_days or list(filter(lambda day: day == current_day_of_week, allowed_days)):
                     return hour_from - current_hour
                 else:
                     return (hour_from - current_hour) + (get_next_day_of_week_diff(current_day_of_week, allowed_days) * 24)

--- a/celery/models/celery_task_setting.py
+++ b/celery/models/celery_task_setting.py
@@ -29,12 +29,30 @@ class CeleryTaskSetting(models.Model):
     )
     use_first_empty_queue = fields.Boolean(string="Use the first queue with N or less pending tasks", default=True)
     active = fields.Boolean(string='Active', default=True, track_visibility='onchange')
+    
+    schedule = fields.Boolean(string="Schedule?", default=False)
+    schedule_mondays = fields.Boolean(string="Schedule on Mondays", default=False)
+    schedule_tuesdays = fields.Boolean(string="Schedule on Tuesdays", default=False)
+    schedule_wednesdays = fields.Boolean(string="Schedule on Wednesdays", default=False)
+    schedule_thursdays = fields.Boolean(string="Schedule on Thursdays", default=False)
+    schedule_fridays = fields.Boolean(string="Schedule on Fridays", default=False)
+    schedule_saturdays = fields.Boolean(string="Schedule on Saturdays", default=False)
+    schedule_sundays = fields.Boolean(string="Schedule on Sundays", default=False)
+    schedule_hours_from = fields.Float(string='Schedule hours from', default=0.0)
+    schedule_hours_to = fields.Float(string='Schedule hours to', default=0.0)
 
     @api.constrains('model', 'method')
     def _check_model_method_unique(self):
         count = self.search_count([('model', '=', self.model), ('method', '=', self.method)])
         if count > 1:
             raise ValidationError(_('Combination of Model and Method already exists!'))
+
+    @api.constrains('schedule_hours_from', 'schedule_hours_to')
+    def _check_hour_range(self):
+        if self.schedule_hours_from > self.schedule_hours_to:
+            raise ValidationError(_('Only same-day hourly range is allowed (00-24)!'))
+        if (self.schedule_hours_from < 0 or self.schedule_hours_from > 24) or (self.schedule_hours_to < 0 or self.schedule_hours_to > 24):
+            raise ValidationError(_('00-24 only!'))
 
     @api.depends('model', 'method')
     def _compute_name(self):

--- a/celery/views/celery_task_setting_views.xml
+++ b/celery/views/celery_task_setting_views.xml
@@ -15,6 +15,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                     <field name="handle_jammed"/>
                     <field name="jammed_after_seconds"/>
                     <field name="handle_jammed_by_cron"/>
+                    <field name="schedule"/>
                     <field name="active"/>
                 </tree>
             </field>
@@ -66,6 +67,28 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                                     </group>
                                     <group attrs="{'invisible': [('handle_jammed', '=', False)]}">
                                         <field name="handle_jammed_by_cron"/>
+                                    </group>
+                                </group>
+                            </page>
+                            <page string="Scheduling" name="tab_scheduling">
+                                <group name="scheduling">
+                                    <group colspan="4">
+                                        <field name="schedule"/>
+                                    </group>
+                                    <group colspan="4" cols="4">
+                                        <group attrs="{'invisible': [('schedule', '=', False)]}" colspan="2" cols="2" string="Days:">
+                                            <field name="schedule_mondays" string="Monday"/>
+                                            <field name="schedule_tuesdays" string="Tuesday"/>
+                                            <field name="schedule_wednesdays" string="Wednesday"/>
+                                            <field name="schedule_thursdays" string="Thursday"/>
+                                            <field name="schedule_fridays" string="Friday"/>
+                                            <field name="schedule_saturdays" string="Saturday"/>
+                                            <field name="schedule_sundays" string="Sunday"/>
+                                        </group>
+                                        <group attrs="{'invisible': [('schedule', '=', False)]}" colspan="2" cols="2" string="Hours:">
+                                            <field name="schedule_hours_from" string="From" widget="float_time"/>
+                                            <field name="schedule_hours_to" string="To" widget="float_time"/>
+                                        </group>
                                     </group>
                                 </group>
                             </page>

--- a/celery/views/celery_task_views.xml
+++ b/celery/views/celery_task_views.xml
@@ -10,7 +10,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
 	    <field name="type">tree</field>
 	    <field name="arch" type="xml">
 		<tree string="Celery Tasks" create="false"
-                      decoration-muted="state in ('SUCCESS', 'CANCEL')" decoration-danger="state == 'FAILURE'">
+                      decoration-muted="state in ('SUCCESS', 'CANCEL')" decoration-danger="state == 'FAILURE'" decoration-info="state == 'SCHEDULED'">
 		    <field name="uuid"/>
                     <field name="model"/>
                     <field name="method"/>
@@ -147,6 +147,16 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                             domain="[('state', '=', 'JAMMED')]"/>
                     <filter name="cancel" string="Cancel"
                             domain="[('state', '=', 'CANCEL')]"/>
+                    <separator/>
+                    <filter name="today" string="Added Today" domain="[('create_date','&gt;', (context_today() - datetime.timedelta(days=1)).strftime('%%Y-%%m-%%d') )]"/>
+                    <filter name="this_week" string="Added In The Last 7 Days" domain="[('create_date','&gt;', (context_today() - datetime.timedelta(days=7)).strftime('%%Y-%%m-%%d') )]"/>
+                    <filter name="this_month" string="Added In The Last 30 Days" domain="[('create_date','&gt;', (context_today() - datetime.timedelta(days=30)).strftime('%%Y-%%m-%%d') )]"/>
+                    <filter name="this_year" string="Added This Year" domain="[('create_date','&lt;=', time.strftime('%%Y-12-31')),('create_date','&gt;=',time.strftime('%%Y-01-01'))]"/>
+                    <separator/>
+                    <filter name="scheduled_today" string="Scheduled Today" domain="[('state','=','SCHEDULED'),('scheduled_date','&gt;=', datetime.datetime.now()),('scheduled_date','&lt;=',(context_today() + datetime.timedelta(days=1)).strftime('%%Y-%%m-%%d') )]"/>
+                    <filter name="scheduled_next_7days" string="Scheduled In the Next 7 days" domain="[('state','=','SCHEDULED'),('scheduled_date','&gt;=', datetime.datetime.now()),('scheduled_date','&lt;=',(context_today() + datetime.timedelta(days=7)).strftime('%%Y-%%m-%%d') )]"/>
+                    <filter name="scheduled_in_the_past" string="Scheduled Past Today" domain="[('state','=','SCHEDULED'),('scheduled_date','&lt;=', datetime.datetime.now())]"/>
+                    <separator/>
 		    <group expand="0" string="Group By">
 	                <filter string="Model" name="model" domain="[]" context="{'group_by': 'model'}"/>
 	                <filter string="Task/method" name="method" domain="[]" context="{'group_by': 'method'}"/>

--- a/celery/views/celery_task_views.xml
+++ b/celery/views/celery_task_views.xml
@@ -19,6 +19,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                     <field name="create_date" readonly="1"/>
                     <field name="started_date"/>
                     <field name="state_date"/>
+                    <field name="scheduled_date"/>
                     <field name="state"/>
 		</tree>
 	    </field>
@@ -34,7 +35,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                         <button
                             name="action_open_related_record" type="object" string="Related"
                             attrs="{'invisible': [('res_model', '=', False)]}"/>
-                        <field name="state" widget="statusbar" statusbar_visible="PENDING,STARTED,RETRY,RETRYING,FAILURE,SUCCESS"/>
+                        <field name="state" widget="statusbar" statusbar_visible="PENDING,STARTED,SCHEDULED,RETRY,RETRYING,FAILURE,SUCCESS"/>
                     </header>
                     <sheet>
                         <!-- fa-retweet (icon): because fontawesome fa-refresh isn't available in Odoo yet. -->
@@ -54,6 +55,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                             <group>
                                 <field name="queue"/>
                                 <field name="create_date"/>
+                                <field name="scheduled_date"/>
                                 <field name="started_date"/>
                                 <field name="state_date"/>
                                 <field name="user_id"/>
@@ -129,6 +131,8 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                     <field name="queue"/>
                     <filter name="pending" string="Pending"
                             domain="[('state', '=', 'PENDING')]"/>
+                    <filter name="scheduled" string="Scheduled"
+                            domain="[('state', '=', 'SCHEDULED')]"/>
                     <filter name="started" string="Started"
                             domain="[('state', '=', 'STARTED')]"/>
                     <filter name="retry" string="Retry"


### PR DESCRIPTION
Adding new task scheduling features, which enables the tasks to be scheduled at certain days of the week and/or certain hourly intervals of the day.

It adds a new tab to the `celery.task.setting` form:

![image](https://user-images.githubusercontent.com/3459102/68761139-be980300-0613-11ea-9320-101392345f36.png)

If the `Schedule?` flag is enabled for a certain type of a task, those tasks will be put to the `Scheduled` state and will not be sent to the MQ. 
Instead, when the `scheduled_date` comes, a cron job handles them and actually sends them to the queue.

TODO: I'm testing it at the moment and plan to add unit tests for this part, mainly to check the datetime scheduling logic in the `check_schedule_needed` method which is a bit 'heavy' already (but the few test cases I've tried so far work correctly). I will update the PR (and port to v12 once ready).