### PR TITLE
[FIX] importing an exception that is used in the code

### DIFF
--- a/celery/models/res_users.py
+++ b/celery/models/res_users.py
@@ -4,6 +4,7 @@
 import contextlib
 
 from odoo import api, models, tools
+from odoo.exceptions import AccessDenied
 from odoo.addons.celery.models.celery_task import _get_celery_user_config
 
 


### PR DESCRIPTION
In line 23, an AccessDenied error is raised if no password was passed to the function, but this exception is not imported