### PR TITLE
Implement broker connection based on env.vars

### DIFF
--- a/celery/odoo.py
+++ b/celery/odoo.py
@@ -8,7 +8,7 @@ from celery.contrib import rdb
 from celery.exceptions import TaskError, Retry, MaxRetriesExceededError
 from celery.utils.log import get_task_logger
 from xmlrpc import client as xmlrpc_client
-
+import os 
 logger = get_task_logger(__name__)
 
 TASK_DEFAULT_QUEUE = 'celery'
@@ -32,7 +32,10 @@ class RunTaskFailure(TaskError):
     """Error from rpc_run_task in Odoo."""
 
 
-app = Celery('odoo.addons.celery')
+app = Celery('odoo.addons.celery',
+            broker_url=os.environ.get('ODOO_CELERY_BROKER', False),
+            broker_heartbeat=os.environ.get('ODOO_CELERY_BROKER_HEARTBEAT', False),
+            worker_prefetch_multiplier=os.environ.get('ODOO_CELERY_WORKER_PREFETCH_MULTIPLIER', False))
 
 @app.task(name='odoo.addons.celery.odoo.call_task', bind=True)
 def call_task(self, url, db, user_id, task_uuid, model, method, **kwargs):

--- a/celery/odoo.py
+++ b/celery/odoo.py
@@ -2,13 +2,14 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 import copy
+import os
 
 from celery import Celery
 from celery.contrib import rdb
 from celery.exceptions import TaskError, Retry, MaxRetriesExceededError
 from celery.utils.log import get_task_logger
 from xmlrpc import client as xmlrpc_client
-import os 
+ 
 logger = get_task_logger(__name__)
 
 TASK_DEFAULT_QUEUE = 'celery'

--- a/celery/static/description/index.html
+++ b/celery/static/description/index.html
@@ -213,6 +213,9 @@ celery = {
             <p class="oe_mb16">(OS) Environment variables of the user running the Odoo server process: <code>ODOO_CELERY_USER</code> and <code>ODOO_CELERY_PASSWORD</code></p>
           </li>
           <li>
+	   <p class="oe_mb16">(OS) Environment variables for third-party broker: <code>ODOO_CELERY_BROKER</code>, <code>ODOO_CELERY_BROKER_HEARTBEAT</code>, <code>ODOO_CELERY_WORKER_PREFETCH_MULTIPLIER</code></p>
+	  </li>
+          <li>
             <p>Put in the <code>odoo.conf</code> file, e.g:
               <pre style="background-color: #dedede;">
 celery_user = Odoo-User


### PR DESCRIPTION
Added:
  - ODOO_CELERY_BROKER - Broker URL
  - ODOO_CELERY_BROKER_HEARTBEAT -  The heartbeat will be monitored at the interval specified
  - ODOO_CELERY_WORKER_PREFETCH_MULTIPLIER - How many messages to prefetch at a time multiplied by the number of concurrent processes

See also:
  - https://github.com/novacode-nl/odoo-celery/pull/40